### PR TITLE
Fixed comfa model loading issue.

### DIFF
--- a/comfa/comfa.cpp
+++ b/comfa/comfa.cpp
@@ -558,7 +558,7 @@ void fpredict(string modelfn, string predfn) {
 	   else beta[i] = atof(stats.substr(0,comma).c_str());
     }
 
-    mpredict(nFpts, predfn, intcpt, beta, ster, elec, npts, lo);
+    mpredict(nFpts*2, predfn, intcpt, beta, ster, elec, npts, lo);
 
 }
 

--- a/comfa/comfa.cpp
+++ b/comfa/comfa.cpp
@@ -548,7 +548,7 @@ void fpredict(string modelfn, string predfn) {
 
     double intcpt;
     mdl >> intcpt;
-    double *beta = new double[nFpts];
+    double *beta = new double[nFpts * 2];
     
 //    for (int i = 0; i < 2 * nFpts; i++) mdl >> beta[i];
     for (int i = 0; i < 2 * nFpts; i++) {


### PR DESCRIPTION
The size for array "beta" is nFpts needed a minor correction (nFpts * 2 instead of nFpts) to load the full model (the for loop for model loading will fail with illegal memory access otherwise).